### PR TITLE
Disable STOP_LIGHT platform idle state

### DIFF
--- a/driver/power/imx6pep/sys/mx6acpi.cpp
+++ b/driver/power/imx6pep/sys/mx6acpi.cpp
@@ -36,8 +36,6 @@ namespace { // static
         CSU_INDEX_INVALID,                      // CPU3
         CSU_SLAVE_INDEX(1, CSU_SLAVE_HIGH),     // GPT
         CSU_SLAVE_INDEX(1, CSU_SLAVE_HIGH),     // EPIT1
-        CSU_SLAVE_INDEX(1, CSU_SLAVE_HIGH),     // EPIT2
-        CSU_SLAVE_INDEX(1, CSU_SLAVE_HIGH),     // RTC
         CSU_SLAVE_INDEX(11, CSU_SLAVE_HIGH),    // I2C1
         CSU_SLAVE_INDEX(12, CSU_SLAVE_LOW),     // I2C2
         CSU_SLAVE_INDEX(12, CSU_SLAVE_HIGH),    // I2C3

--- a/driver/power/imx6pep/sys/mx6dpm.cpp
+++ b/driver/power/imx6pep/sys/mx6dpm.cpp
@@ -36,10 +36,8 @@ namespace { // static
         RTL_CONSTANT_STRING(L"\\_SB.CPU1"),      // CPU1
         RTL_CONSTANT_STRING(L"\\_SB.CPU2"),      // CPU2
         RTL_CONSTANT_STRING(L"\\_SB.CPU3"),      // CPU3
-        RTL_CONSTANT_STRING(L"VEN_NXP&DEV_0101&SUBDEV_0000&REV_0000&UID_00000003"), // GPT
-        RTL_CONSTANT_STRING(L"VEN_NXP&DEV_0101&SUBDEV_0000&REV_0000&UID_00000004"), // EPIT1
-        RTL_CONSTANT_STRING(L"VEN_NXP&DEV_0101&SUBDEV_0000&REV_0000&UID_00000005"), // EPIT2
-        RTL_CONSTANT_STRING(L"VEN_NXP&DEV_0101&SUBDEV_0000&REV_0000&UID_00000006"), // RTC
+        RTL_CONSTANT_STRING(L"VEN_NXPI&DEV_0101&SUBDEV_0000&REV_0000&UID_00000003"), // GPT
+        RTL_CONSTANT_STRING(L"VEN_NXPI&DEV_0101&SUBDEV_0000&REV_0000&UID_00000004"), // EPIT1
         RTL_CONSTANT_STRING(L"\\_SB.I2C1"),      // I2C1
         RTL_CONSTANT_STRING(L"\\_SB.I2C2"),      // I2C2
         RTL_CONSTANT_STRING(L"\\_SB.I2C3"),      // I2C3
@@ -470,8 +468,6 @@ BOOLEAN MX6_PEP::DpmDeviceIdleContraints (
         {{ PowerDeviceUnspecified }},                                   // CPU3
         {{ PowerDeviceUnspecified }},                                   // GPT (core system resource)
         {{ PowerDeviceUnspecified }},                                   // EPIT1 (core system resource)
-        {{ PowerDeviceUnspecified }},                                   // EPIT2 (core system resource)
-        {{ PowerDeviceUnspecified }},                                   // RTC (core system resource)
         {{ PowerDeviceD0, PowerDeviceD1, PowerDeviceD1 }},              // I2C1 (PERCLK_CLK_ROOT -> IPG_CLK_ROOT -> AHB_CLK_ROOT -> PERIPH_CLK -> PRE_PERIPH_CLK -> PLL2_MAIN_CLK)
         {{ PowerDeviceD0, PowerDeviceD1, PowerDeviceD1 }},              // I2C2
         {{ PowerDeviceD0, PowerDeviceD1, PowerDeviceD1 }},              // I2C3

--- a/driver/power/imx6pep/sys/mx6pep.h
+++ b/driver/power/imx6pep/sys/mx6pep.h
@@ -27,8 +27,6 @@ public: // NONPAGED
         CPU3,
         GPT,
         EPIT1,
-        EPIT2,
-        RTC,
         I2C1,
         I2C2,
         I2C3,

--- a/driver/power/imx6pep/sys/mx6ppm.cpp
+++ b/driver/power/imx6pep/sys/mx6ppm.cpp
@@ -468,22 +468,33 @@ BOOLEAN MX6_PEP::PpmQueryVetoReason (
 _IRQL_requires_max_(PASSIVE_LEVEL)
 BOOLEAN MX6_PEP::PpmEnumerateBootVetoes (PEPHANDLE /*Handle*/)
 {
+    NTSTATUS status;
     POHANDLE cpu0Handle =
             this->contextFromDeviceId(_DEVICE_ID::CPU0)->KernelHandle;
 
     //
-    // ARM off platform idle state is temporarily disabled in multicore config
+    // Disable stop light mode due to always-on counter dependency
     //
-    if (this->activeProcessorCount > 1) {
-        NTSTATUS status = this->pepKernelInfo.PlatformIdleVeto(
-                cpu0Handle,
-                PLATFORM_IDLE_STATE_ARM_OFF,
-                MX6_VETO_REASON_DISABLED,
-                TRUE);
+    status = this->pepKernelInfo.PlatformIdleVeto(
+            cpu0Handle,
+            PLATFORM_IDLE_STATE_STOP_LIGHT,
+            MX6_VETO_REASON_DISABLED,
+            TRUE);
 
-        UNREFERENCED_PARAMETER(status);
-        NT_ASSERT(NT_SUCCESS(status));
-    }
+    UNREFERENCED_PARAMETER(status);
+    NT_ASSERT(NT_SUCCESS(status));
+
+    //
+    // ARM off platform idle state disabled due to lack of PSCI support
+    //
+    status = this->pepKernelInfo.PlatformIdleVeto(
+            cpu0Handle,
+            PLATFORM_IDLE_STATE_ARM_OFF,
+            MX6_VETO_REASON_DISABLED,
+            TRUE);
+
+    UNREFERENCED_PARAMETER(status);
+    NT_ASSERT(NT_SUCCESS(status));
 
     return TRUE;
 }


### PR DESCRIPTION
Fix device IDs for timer resources and disable STOP_LIGHT platform idle state. This state only runs in UpdateOS due to device dependencies and does not get enough coverage to justify having it enabled.