### PR TITLE
Update BSP docs and tooling for IoT ADK AddonKit

### DIFF
--- a/Documentation/adding-drivers.md
+++ b/Documentation/adding-drivers.md
@@ -42,7 +42,6 @@ ServiceBinary  = %13%\MyTestDriver.sys
 4) **If you did not create a new FeatureID, skip this step.** If you created a new FeatureID in your DeviceFM.xml then you must select it in your ProductionOEMInput.xml and TestOEMInput.xml files to include the driver in the respective image (e.g. HummingBoard Edge iMX6Q uses `imx-iotcore\build\board\HummingBoardEdge_iMX6Q_2GB\HummingBoardEdge_iMX6Q_2GB_TestOEMInput.xml` and `imx-iotcore\build\board\HummingBoardEdge_iMX6Q_2GB\HummingBoardEdge_iMX6Q_2GB_ProductionOEMInput.xml`).
 ```XML
 <OEM>
-  <Feature>TEST</Feature>
   <Feature>MYNEWFEATURE_DRIVERS</Feature>
   <Feature>IMX_DRIVERS</Feature>
 </OEM>

--- a/README.md
+++ b/README.md
@@ -100,14 +100,17 @@ call BuildImage Sabre_iMX6Q_1GB Sabre_iMX6Q_1GB_TestOEMInput.xml
 
 ### Building the FFU with the IoT ADK AddonKit
 1. Build the GenerateBSP project to create a BSP folder in the root of the repository.
-2. Setup the IoT ADK AddonKit (https://github.com/ms-iot/iot-adk-addonkit) following the instructions from the IoT Core Manufacturing Guide (https://docs.microsoft.com/en-us/windows-hardware/manufacture/iot/iot-core-manufacturing-guide)
-3. Copy the BSP\HummingBoard folder to iot-adk-addonkit\Workspace\Source-arm\BSP\
-* Open an IoT ADK AddonKit environment with `iot-adk-addonkit\IoTCoreShell-arm.cmd`
-* Run `set SIGNFILES=NONE`
-    * This is to stop the ADK AddonKit from resigning the HAL Extensions with an unbootable signature.
-* Run `buildpkg.cmd all`
-* Run `newproduct.cmd HummingBoard HummingBoardEdge_iMX6Q_2GB`
-* Run `buildimage.cmd HummingBoard Test`
+2. Clone the [IoT ADK AddonKit](https://github.com/ms-iot/iot-adk-addonkit).
+3. Follow the [Create a basic image instructions](https://docs.microsoft.com/en-us/windows-hardware/manufacture/iot/create-a-basic-image) from the IoT Core Manufacturing guide with the following changes.
+* When importing a BSP use one of the board names from the newly generated BSP folder in the imx-iotcore repo.
+    ```
+    Import-IoTBSP HummingBoardEdge_iMX6Q_2GB <Path to imx-iotcore\BSP>
+    ```
+* When creating a product use the same board name from the BSP import.
+    ```
+    Add-IoTProduct ProductA HummingBoardEdge_iMX6Q_2GB
+    ```
+
 
 # Building Firmware from Source
 

--- a/build/board/ClSomImx7_iMX7D_1GB/ClSomImx7_iMX7D_1GB_TestOEMInput.xml
+++ b/build/board/ClSomImx7_iMX7D_1GB/ClSomImx7_iMX7D_1GB_TestOEMInput.xml
@@ -33,11 +33,9 @@
   <Feature>IOT_EFIESP</Feature>
   <Feature>IOT_EFIESP_BCD_MBR</Feature>
   <Feature>IOT_APP_TOOLKIT</Feature>
-  <Feature>IOT_CORTANA</Feature>
   <Feature>IOT_SHELL_HOTKEY_SUPPORT</Feature>
   <Feature>IOT_SIREP</Feature>
   <Feature>IOT_SSH</Feature>
-  <Feature>IOT_APPLICATIONS</Feature>
   <Feature>IOT_BERTHA</Feature>
   <Feature>IOT_UAP_OOBE</Feature>
   <Feature>IOT_WEBB_EXTN</Feature>
@@ -56,7 +54,6 @@
   <Feature>IOT_NANORDPSERVER</Feature>
 </Microsoft>
 <OEM>
-  <Feature>TEST</Feature>
   <Feature>IMX_DRIVERS</Feature>
 </OEM>
 </Features>

--- a/build/board/EVK_iMX6ULL_512MB/EVK_iMX6ULL_512MB_ProductionOEMInput.xml
+++ b/build/board/EVK_iMX6ULL_512MB/EVK_iMX6ULL_512MB_ProductionOEMInput.xml
@@ -32,11 +32,9 @@
   <Feature>IOT_EFIESP</Feature>
   <Feature>IOT_EFIESP_BCD_MBR</Feature>
   <Feature>IOT_APP_TOOLKIT</Feature>
-  <Feature>IOT_CORTANA</Feature>
   <Feature>IOT_SHELL_HOTKEY_SUPPORT</Feature>
   <Feature>IOT_SIREP</Feature>
   <Feature>IOT_SSH</Feature>
-  <Feature>IOT_APPLICATIONS</Feature>
   <Feature>IOT_BERTHA</Feature>
   <Feature>IOT_UAP_OOBE</Feature>
   <Feature>IOT_WEBB_EXTN</Feature>
@@ -55,7 +53,6 @@
   <Feature>IOT_NANORDPSERVER</Feature>
 </Microsoft>
 <OEM>
-  <Feature>PRODUCTION</Feature>
   <Feature>IMX_DRIVERS</Feature>
 </OEM>
 </Features>

--- a/build/board/EVK_iMX6ULL_512MB/EVK_iMX6ULL_512MB_TestOEMInput.xml
+++ b/build/board/EVK_iMX6ULL_512MB/EVK_iMX6ULL_512MB_TestOEMInput.xml
@@ -33,11 +33,9 @@
   <Feature>IOT_EFIESP</Feature>
   <Feature>IOT_EFIESP_BCD_MBR</Feature>
   <Feature>IOT_APP_TOOLKIT</Feature>
-  <Feature>IOT_CORTANA</Feature>
   <Feature>IOT_SHELL_HOTKEY_SUPPORT</Feature>
   <Feature>IOT_SIREP</Feature>
   <Feature>IOT_SSH</Feature>
-  <Feature>IOT_APPLICATIONS</Feature>
   <Feature>IOT_BERTHA</Feature>
   <Feature>IOT_UAP_OOBE</Feature>
   <Feature>IOT_WEBB_EXTN</Feature>
@@ -56,7 +54,6 @@
   <Feature>IOT_NANORDPSERVER</Feature>
 </Microsoft>
 <OEM>
-  <Feature>TEST</Feature>
   <Feature>IMX_DRIVERS</Feature>
 </OEM>
 </Features>

--- a/build/board/HummingBoardEdge_iMX6DL_1GB/HummingBoardEdge_iMX6DL_1GB_ProductionOEMInput.xml
+++ b/build/board/HummingBoardEdge_iMX6DL_1GB/HummingBoardEdge_iMX6DL_1GB_ProductionOEMInput.xml
@@ -32,11 +32,9 @@
   <Feature>IOT_EFIESP</Feature>
   <Feature>IOT_EFIESP_BCD_MBR</Feature>
   <Feature>IOT_APP_TOOLKIT</Feature>
-  <Feature>IOT_CORTANA</Feature>
   <Feature>IOT_SHELL_HOTKEY_SUPPORT</Feature>
   <Feature>IOT_SIREP</Feature>
   <Feature>IOT_SSH</Feature>
-  <Feature>IOT_APPLICATIONS</Feature>
   <Feature>IOT_BERTHA</Feature>
   <Feature>IOT_UAP_OOBE</Feature>
   <Feature>IOT_WEBB_EXTN</Feature>
@@ -55,7 +53,6 @@
   <Feature>IOT_NANORDPSERVER</Feature>
 </Microsoft>
 <OEM>
-  <Feature>PRODUCTION</Feature>
   <Feature>IMX_DRIVERS</Feature>
 </OEM>
 </Features>

--- a/build/board/HummingBoardEdge_iMX6DL_1GB/HummingBoardEdge_iMX6DL_1GB_TestOEMInput.xml
+++ b/build/board/HummingBoardEdge_iMX6DL_1GB/HummingBoardEdge_iMX6DL_1GB_TestOEMInput.xml
@@ -33,11 +33,9 @@
   <Feature>IOT_EFIESP</Feature>
   <Feature>IOT_EFIESP_BCD_MBR</Feature>
   <Feature>IOT_APP_TOOLKIT</Feature>
-  <Feature>IOT_CORTANA</Feature>
   <Feature>IOT_SHELL_HOTKEY_SUPPORT</Feature>
   <Feature>IOT_SIREP</Feature>
   <Feature>IOT_SSH</Feature>
-  <Feature>IOT_APPLICATIONS</Feature>
   <Feature>IOT_BERTHA</Feature>
   <Feature>IOT_UAP_OOBE</Feature>
   <Feature>IOT_WEBB_EXTN</Feature>
@@ -56,7 +54,6 @@
   <Feature>IOT_NANORDPSERVER</Feature>
 </Microsoft>
 <OEM>
-  <Feature>TEST</Feature>
   <Feature>IMX_DRIVERS</Feature>
 </OEM>
 </Features>

--- a/build/board/HummingBoardEdge_iMX6Q_2GB/HummingBoardEdge_iMX6Q_2GB_ProductionOEMInput.xml
+++ b/build/board/HummingBoardEdge_iMX6Q_2GB/HummingBoardEdge_iMX6Q_2GB_ProductionOEMInput.xml
@@ -24,7 +24,7 @@
   </Resolutions>
   <AdditionalFMs>
     <AdditionalFM>%AKROOT%\FMFiles\arm\IoTUAPNonProductionPartnerShareFM.xml</AdditionalFM>
-    <AdditionalFM>%BLD_DIR%\MergedFMs\HummingBoardDeviceFM.xml</AdditionalFM>
+    <AdditionalFM>%BLD_DIR%\MergedFMs\HummingBoardEdge_iMX6Q_2GB_DeviceFM.xml</AdditionalFM>
   </AdditionalFMs>
 <Features>
 <Microsoft>
@@ -32,11 +32,9 @@
   <Feature>IOT_EFIESP</Feature>
   <Feature>IOT_EFIESP_BCD_MBR</Feature>
   <Feature>IOT_APP_TOOLKIT</Feature>
-  <Feature>IOT_CORTANA</Feature>
   <Feature>IOT_SHELL_HOTKEY_SUPPORT</Feature>
   <Feature>IOT_SIREP</Feature>
   <Feature>IOT_SSH</Feature>
-  <Feature>IOT_APPLICATIONS</Feature>
   <Feature>IOT_BERTHA</Feature>
   <Feature>IOT_UAP_OOBE</Feature>
   <Feature>IOT_WEBB_EXTN</Feature>
@@ -55,7 +53,6 @@
   <Feature>IOT_NANORDPSERVER</Feature>
 </Microsoft>
 <OEM>
-  <Feature>PRODUCTION</Feature>
   <Feature>IMX_DRIVERS</Feature>
 </OEM>
 </Features>

--- a/build/board/HummingBoardEdge_iMX6Q_2GB/HummingBoardEdge_iMX6Q_2GB_TestOEMInput.xml
+++ b/build/board/HummingBoardEdge_iMX6Q_2GB/HummingBoardEdge_iMX6Q_2GB_TestOEMInput.xml
@@ -33,11 +33,9 @@
   <Feature>IOT_EFIESP</Feature>
   <Feature>IOT_EFIESP_BCD_MBR</Feature>
   <Feature>IOT_APP_TOOLKIT</Feature>
-  <Feature>IOT_CORTANA</Feature>
   <Feature>IOT_SHELL_HOTKEY_SUPPORT</Feature>
   <Feature>IOT_SIREP</Feature>
   <Feature>IOT_SSH</Feature>
-  <Feature>IOT_APPLICATIONS</Feature>
   <Feature>IOT_BERTHA</Feature>
   <Feature>IOT_UAP_OOBE</Feature>
   <Feature>IOT_WEBB_EXTN</Feature>
@@ -56,7 +54,6 @@
   <Feature>IOT_NANORDPSERVER</Feature>
 </Microsoft>
 <OEM>
-  <Feature>TEST</Feature>
   <Feature>IMX_DRIVERS</Feature>
 </OEM>
 </Features>

--- a/build/board/HummingBoardEdge_iMX6S_512MB/HummingBoardEdge_iMX6S_512MB_ProductionOEMInput.xml
+++ b/build/board/HummingBoardEdge_iMX6S_512MB/HummingBoardEdge_iMX6S_512MB_ProductionOEMInput.xml
@@ -32,11 +32,9 @@
   <Feature>IOT_EFIESP</Feature>
   <Feature>IOT_EFIESP_BCD_MBR</Feature>
   <Feature>IOT_APP_TOOLKIT</Feature>
-  <Feature>IOT_CORTANA</Feature>
   <Feature>IOT_SHELL_HOTKEY_SUPPORT</Feature>
   <Feature>IOT_SIREP</Feature>
   <Feature>IOT_SSH</Feature>
-  <Feature>IOT_APPLICATIONS</Feature>
   <Feature>IOT_BERTHA</Feature>
   <Feature>IOT_UAP_OOBE</Feature>
   <Feature>IOT_WEBB_EXTN</Feature>
@@ -55,7 +53,6 @@
   <Feature>IOT_NANORDPSERVER</Feature>
 </Microsoft>
 <OEM>
-  <Feature>PRODUCTION</Feature>
   <Feature>IMX_DRIVERS</Feature>
 </OEM>
 </Features>

--- a/build/board/HummingBoardEdge_iMX6S_512MB/HummingBoardEdge_iMX6S_512MB_TestOEMInput.xml
+++ b/build/board/HummingBoardEdge_iMX6S_512MB/HummingBoardEdge_iMX6S_512MB_TestOEMInput.xml
@@ -33,11 +33,9 @@
   <Feature>IOT_EFIESP</Feature>
   <Feature>IOT_EFIESP_BCD_MBR</Feature>
   <Feature>IOT_APP_TOOLKIT</Feature>
-  <Feature>IOT_CORTANA</Feature>
   <Feature>IOT_SHELL_HOTKEY_SUPPORT</Feature>
   <Feature>IOT_SIREP</Feature>
   <Feature>IOT_SSH</Feature>
-  <Feature>IOT_APPLICATIONS</Feature>
   <Feature>IOT_BERTHA</Feature>
   <Feature>IOT_UAP_OOBE</Feature>
   <Feature>IOT_WEBB_EXTN</Feature>
@@ -56,7 +54,6 @@
   <Feature>IOT_NANORDPSERVER</Feature>
 </Microsoft>
 <OEM>
-  <Feature>TEST</Feature>
   <Feature>IMX_DRIVERS</Feature>
 </OEM>
 </Features>

--- a/build/board/RSB4411_iMX6Q_1GB/RSB4411_iMX6Q_1GB_ProductionOEMInput.xml
+++ b/build/board/RSB4411_iMX6Q_1GB/RSB4411_iMX6Q_1GB_ProductionOEMInput.xml
@@ -32,11 +32,9 @@
   <Feature>IOT_EFIESP</Feature>
   <Feature>IOT_EFIESP_BCD_MBR</Feature>
   <Feature>IOT_APP_TOOLKIT</Feature>
-  <Feature>IOT_CORTANA</Feature>
   <Feature>IOT_SHELL_HOTKEY_SUPPORT</Feature>
   <Feature>IOT_SIREP</Feature>
   <Feature>IOT_SSH</Feature>
-  <Feature>IOT_APPLICATIONS</Feature>
   <Feature>IOT_BERTHA</Feature>
   <Feature>IOT_UAP_OOBE</Feature>
   <Feature>IOT_WEBB_EXTN</Feature>
@@ -55,7 +53,6 @@
   <Feature>IOT_NANORDPSERVER</Feature>
 </Microsoft>
 <OEM>
-  <Feature>PRODUCTION</Feature>
   <Feature>IMX_DRIVERS</Feature>
 </OEM>
 </Features>

--- a/build/board/RSB4411_iMX6Q_1GB/RSB4411_iMX6Q_1GB_TestOEMInput.xml
+++ b/build/board/RSB4411_iMX6Q_1GB/RSB4411_iMX6Q_1GB_TestOEMInput.xml
@@ -33,11 +33,9 @@
   <Feature>IOT_EFIESP</Feature>
   <Feature>IOT_EFIESP_BCD_MBR</Feature>
   <Feature>IOT_APP_TOOLKIT</Feature>
-  <Feature>IOT_CORTANA</Feature>
   <Feature>IOT_SHELL_HOTKEY_SUPPORT</Feature>
   <Feature>IOT_SIREP</Feature>
   <Feature>IOT_SSH</Feature>
-  <Feature>IOT_APPLICATIONS</Feature>
   <Feature>IOT_BERTHA</Feature>
   <Feature>IOT_UAP_OOBE</Feature>
   <Feature>IOT_WEBB_EXTN</Feature>
@@ -56,7 +54,6 @@
   <Feature>IOT_NANORDPSERVER</Feature>
 </Microsoft>
 <OEM>
-  <Feature>TEST</Feature>
   <Feature>IMX_DRIVERS</Feature>
 </OEM>
 </Features>

--- a/build/board/SabreLite_iMX6Q_1GB/SabreLite_iMX6Q_1GB_ProductionOEMInput.xml
+++ b/build/board/SabreLite_iMX6Q_1GB/SabreLite_iMX6Q_1GB_ProductionOEMInput.xml
@@ -32,11 +32,9 @@
   <Feature>IOT_EFIESP</Feature>
   <Feature>IOT_EFIESP_BCD_MBR</Feature>
   <Feature>IOT_APP_TOOLKIT</Feature>
-  <Feature>IOT_CORTANA</Feature>
   <Feature>IOT_SHELL_HOTKEY_SUPPORT</Feature>
   <Feature>IOT_SIREP</Feature>
   <Feature>IOT_SSH</Feature>
-  <Feature>IOT_APPLICATIONS</Feature>
   <Feature>IOT_BERTHA</Feature>
   <Feature>IOT_UAP_OOBE</Feature>
   <Feature>IOT_WEBB_EXTN</Feature>
@@ -55,7 +53,6 @@
   <Feature>IOT_NANORDPSERVER</Feature>
 </Microsoft>
 <OEM>
-  <Feature>PRODUCTION</Feature>
   <Feature>IMX_DRIVERS</Feature>
 </OEM>
 </Features>

--- a/build/board/SabreLite_iMX6Q_1GB/SabreLite_iMX6Q_1GB_TestOEMInput.xml
+++ b/build/board/SabreLite_iMX6Q_1GB/SabreLite_iMX6Q_1GB_TestOEMInput.xml
@@ -33,11 +33,9 @@
   <Feature>IOT_EFIESP</Feature>
   <Feature>IOT_EFIESP_BCD_MBR</Feature>
   <Feature>IOT_APP_TOOLKIT</Feature>
-  <Feature>IOT_CORTANA</Feature>
   <Feature>IOT_SHELL_HOTKEY_SUPPORT</Feature>
   <Feature>IOT_SIREP</Feature>
   <Feature>IOT_SSH</Feature>
-  <Feature>IOT_APPLICATIONS</Feature>
   <Feature>IOT_BERTHA</Feature>
   <Feature>IOT_UAP_OOBE</Feature>
   <Feature>IOT_WEBB_EXTN</Feature>
@@ -56,7 +54,6 @@
   <Feature>IOT_NANORDPSERVER</Feature>
 </Microsoft>
 <OEM>
-  <Feature>TEST</Feature>
   <Feature>IMX_DRIVERS</Feature>
 </OEM>
 </Features>

--- a/build/board/Sabre_iMX6QP_1GB/Sabre_iMX6QP_1GB_ProductionOEMInput.xml
+++ b/build/board/Sabre_iMX6QP_1GB/Sabre_iMX6QP_1GB_ProductionOEMInput.xml
@@ -32,11 +32,9 @@
   <Feature>IOT_EFIESP</Feature>
   <Feature>IOT_EFIESP_BCD_MBR</Feature>
   <Feature>IOT_APP_TOOLKIT</Feature>
-  <Feature>IOT_CORTANA</Feature>
   <Feature>IOT_SHELL_HOTKEY_SUPPORT</Feature>
   <Feature>IOT_SIREP</Feature>
   <Feature>IOT_SSH</Feature>
-  <Feature>IOT_APPLICATIONS</Feature>
   <Feature>IOT_BERTHA</Feature>
   <Feature>IOT_UAP_OOBE</Feature>
   <Feature>IOT_WEBB_EXTN</Feature>
@@ -55,7 +53,6 @@
   <Feature>IOT_NANORDPSERVER</Feature>
 </Microsoft>
 <OEM>
-  <Feature>PRODUCTION</Feature>
   <Feature>IMX_DRIVERS</Feature>
 </OEM>
 </Features>

--- a/build/board/Sabre_iMX6QP_1GB/Sabre_iMX6QP_1GB_TestOEMInput.xml
+++ b/build/board/Sabre_iMX6QP_1GB/Sabre_iMX6QP_1GB_TestOEMInput.xml
@@ -33,11 +33,9 @@
   <Feature>IOT_EFIESP</Feature>
   <Feature>IOT_EFIESP_BCD_MBR</Feature>
   <Feature>IOT_APP_TOOLKIT</Feature>
-  <Feature>IOT_CORTANA</Feature>
   <Feature>IOT_SHELL_HOTKEY_SUPPORT</Feature>
   <Feature>IOT_SIREP</Feature>
   <Feature>IOT_SSH</Feature>
-  <Feature>IOT_APPLICATIONS</Feature>
   <Feature>IOT_BERTHA</Feature>
   <Feature>IOT_UAP_OOBE</Feature>
   <Feature>IOT_WEBB_EXTN</Feature>
@@ -56,7 +54,6 @@
   <Feature>IOT_NANORDPSERVER</Feature>
 </Microsoft>
 <OEM>
-  <Feature>TEST</Feature>
   <Feature>IMX_DRIVERS</Feature>
 </OEM>
 </Features>

--- a/build/board/Sabre_iMX6Q_1GB/Sabre_iMX6Q_1GB_ProductionOEMInput.xml
+++ b/build/board/Sabre_iMX6Q_1GB/Sabre_iMX6Q_1GB_ProductionOEMInput.xml
@@ -32,11 +32,9 @@
   <Feature>IOT_EFIESP</Feature>
   <Feature>IOT_EFIESP_BCD_MBR</Feature>
   <Feature>IOT_APP_TOOLKIT</Feature>
-  <Feature>IOT_CORTANA</Feature>
   <Feature>IOT_SHELL_HOTKEY_SUPPORT</Feature>
   <Feature>IOT_SIREP</Feature>
   <Feature>IOT_SSH</Feature>
-  <Feature>IOT_APPLICATIONS</Feature>
   <Feature>IOT_BERTHA</Feature>
   <Feature>IOT_UAP_OOBE</Feature>
   <Feature>IOT_WEBB_EXTN</Feature>
@@ -55,7 +53,6 @@
   <Feature>IOT_NANORDPSERVER</Feature>
 </Microsoft>
 <OEM>
-  <Feature>PRODUCTION</Feature>
   <Feature>IMX_DRIVERS</Feature>
 </OEM>
 </Features>

--- a/build/board/Sabre_iMX6Q_1GB/Sabre_iMX6Q_1GB_TestOEMInput.xml
+++ b/build/board/Sabre_iMX6Q_1GB/Sabre_iMX6Q_1GB_TestOEMInput.xml
@@ -33,11 +33,9 @@
   <Feature>IOT_EFIESP</Feature>
   <Feature>IOT_EFIESP_BCD_MBR</Feature>
   <Feature>IOT_APP_TOOLKIT</Feature>
-  <Feature>IOT_CORTANA</Feature>
   <Feature>IOT_SHELL_HOTKEY_SUPPORT</Feature>
   <Feature>IOT_SIREP</Feature>
   <Feature>IOT_SSH</Feature>
-  <Feature>IOT_APPLICATIONS</Feature>
   <Feature>IOT_BERTHA</Feature>
   <Feature>IOT_UAP_OOBE</Feature>
   <Feature>IOT_WEBB_EXTN</Feature>
@@ -56,7 +54,6 @@
   <Feature>IOT_NANORDPSERVER</Feature>
 </Microsoft>
 <OEM>
-  <Feature>TEST</Feature>
   <Feature>IMX_DRIVERS</Feature>
 </OEM>
 </Features>

--- a/build/board/Sabre_iMX7D_1GB/Sabre_iMX7D_1GB_TestOEMInput.xml
+++ b/build/board/Sabre_iMX7D_1GB/Sabre_iMX7D_1GB_TestOEMInput.xml
@@ -33,11 +33,9 @@
   <Feature>IOT_EFIESP</Feature>
   <Feature>IOT_EFIESP_BCD_MBR</Feature>
   <Feature>IOT_APP_TOOLKIT</Feature>
-  <Feature>IOT_CORTANA</Feature>
   <Feature>IOT_SHELL_HOTKEY_SUPPORT</Feature>
   <Feature>IOT_SIREP</Feature>
   <Feature>IOT_SSH</Feature>
-  <Feature>IOT_APPLICATIONS</Feature>
   <Feature>IOT_BERTHA</Feature>
   <Feature>IOT_UAP_OOBE</Feature>
   <Feature>IOT_WEBB_EXTN</Feature>
@@ -56,7 +54,6 @@
   <Feature>IOT_NANORDPSERVER</Feature>
 </Microsoft>
 <OEM>
-  <Feature>TEST</Feature>
   <Feature>IMX_DRIVERS</Feature>
 </OEM>
 </Features>

--- a/build/board/UdooNeo_iMX6SX_1GB/UdooNeo_iMX6SX_1GB_ProductionOEMInput.xml
+++ b/build/board/UdooNeo_iMX6SX_1GB/UdooNeo_iMX6SX_1GB_ProductionOEMInput.xml
@@ -32,11 +32,9 @@
   <Feature>IOT_EFIESP</Feature>
   <Feature>IOT_EFIESP_BCD_MBR</Feature>
   <Feature>IOT_APP_TOOLKIT</Feature>
-  <Feature>IOT_CORTANA</Feature>
   <Feature>IOT_SHELL_HOTKEY_SUPPORT</Feature>
   <Feature>IOT_SIREP</Feature>
   <Feature>IOT_SSH</Feature>
-  <Feature>IOT_APPLICATIONS</Feature>
   <Feature>IOT_BERTHA</Feature>
   <Feature>IOT_UAP_OOBE</Feature>
   <Feature>IOT_WEBB_EXTN</Feature>
@@ -55,7 +53,6 @@
   <Feature>IOT_NANORDPSERVER</Feature>
 </Microsoft>
 <OEM>
-  <Feature>PRODUCTION</Feature>
   <Feature>IMX_DRIVERS</Feature>
 </OEM>
 </Features>

--- a/build/board/UdooNeo_iMX6SX_1GB/UdooNeo_iMX6SX_1GB_TestOEMInput.xml
+++ b/build/board/UdooNeo_iMX6SX_1GB/UdooNeo_iMX6SX_1GB_TestOEMInput.xml
@@ -33,11 +33,9 @@
   <Feature>IOT_EFIESP</Feature>
   <Feature>IOT_EFIESP_BCD_MBR</Feature>
   <Feature>IOT_APP_TOOLKIT</Feature>
-  <Feature>IOT_CORTANA</Feature>
   <Feature>IOT_SHELL_HOTKEY_SUPPORT</Feature>
   <Feature>IOT_SIREP</Feature>
   <Feature>IOT_SSH</Feature>
-  <Feature>IOT_APPLICATIONS</Feature>
   <Feature>IOT_BERTHA</Feature>
   <Feature>IOT_UAP_OOBE</Feature>
   <Feature>IOT_WEBB_EXTN</Feature>
@@ -56,7 +54,6 @@
   <Feature>IOT_NANORDPSERVER</Feature>
 </Microsoft>
 <OEM>
-  <Feature>TEST</Feature>
   <Feature>IMX_DRIVERS</Feature>
 </OEM>
 </Features>

--- a/build/board/VAB820_iMX6Q_1GB/VAB820_iMX6Q_1GB_ProductionOEMInput.xml
+++ b/build/board/VAB820_iMX6Q_1GB/VAB820_iMX6Q_1GB_ProductionOEMInput.xml
@@ -32,11 +32,9 @@
   <Feature>IOT_EFIESP</Feature>
   <Feature>IOT_EFIESP_BCD_MBR</Feature>
   <Feature>IOT_APP_TOOLKIT</Feature>
-  <Feature>IOT_CORTANA</Feature>
   <Feature>IOT_SHELL_HOTKEY_SUPPORT</Feature>
   <Feature>IOT_SIREP</Feature>
   <Feature>IOT_SSH</Feature>
-  <Feature>IOT_APPLICATIONS</Feature>
   <Feature>IOT_BERTHA</Feature>
   <Feature>IOT_UAP_OOBE</Feature>
   <Feature>IOT_WEBB_EXTN</Feature>
@@ -55,7 +53,6 @@
   <Feature>IOT_NANORDPSERVER</Feature>
 </Microsoft>
 <OEM>
-  <Feature>PRODUCTION</Feature>
   <Feature>IMX_DRIVERS</Feature>
 </OEM>
 </Features>

--- a/build/board/VAB820_iMX6Q_1GB/VAB820_iMX6Q_1GB_TestOEMInput.xml
+++ b/build/board/VAB820_iMX6Q_1GB/VAB820_iMX6Q_1GB_TestOEMInput.xml
@@ -33,11 +33,9 @@
   <Feature>IOT_EFIESP</Feature>
   <Feature>IOT_EFIESP_BCD_MBR</Feature>
   <Feature>IOT_APP_TOOLKIT</Feature>
-  <Feature>IOT_CORTANA</Feature>
   <Feature>IOT_SHELL_HOTKEY_SUPPORT</Feature>
   <Feature>IOT_SIREP</Feature>
   <Feature>IOT_SSH</Feature>
-  <Feature>IOT_APPLICATIONS</Feature>
   <Feature>IOT_BERTHA</Feature>
   <Feature>IOT_UAP_OOBE</Feature>
   <Feature>IOT_WEBB_EXTN</Feature>
@@ -56,7 +54,6 @@
   <Feature>IOT_NANORDPSERVER</Feature>
 </Microsoft>
 <OEM>
-  <Feature>TEST</Feature>
   <Feature>IMX_DRIVERS</Feature>
 </OEM>
 </Features>

--- a/build/solution/iMXPlatform/GenerateBSP/GenerateBSP.vcxproj
+++ b/build/solution/iMXPlatform/GenerateBSP/GenerateBSP.vcxproj
@@ -50,12 +50,12 @@
       call ..\..\..\tools\BuildBSP.bat iMX6 HummingBoardEdge_iMX6DL_1GB
       call ..\..\..\tools\BuildBSP.bat iMX6 HummingBoardEdge_iMX6Q_2GB
       call ..\..\..\tools\BuildBSP.bat iMX6 HummingBoardEdge_iMX6S_512MB
-      call ..\..\..\tools\BuildBSP.bat iMX6 RSB4411_iMX6Q_1GB
+      REM call ..\..\..\tools\BuildBSP.bat iMX6 RSB4411_iMX6Q_1GB
       call ..\..\..\tools\BuildBSP.bat iMX6 Sabre_iMX6Q_1GB
       call ..\..\..\tools\BuildBSP.bat iMX6 Sabre_iMX6QP_1GB
-      call ..\..\..\tools\BuildBSP.bat iMX6 SabreLite_iMX6Q_1GB
+      REM call ..\..\..\tools\BuildBSP.bat iMX6 SabreLite_iMX6Q_1GB
       call ..\..\..\tools\BuildBSP.bat iMX6 UdooNeo_iMX6SX_1GB
-      call ..\..\..\tools\BuildBSP.bat iMX6 VAB820_iMX6Q_1GB
+      REM call ..\..\..\tools\BuildBSP.bat iMX6 VAB820_iMX6Q_1GB
       call ..\..\..\tools\BuildBSP.bat iMX7 ClSomImx7_iMX7D_1GB
       call ..\..\..\tools\BuildBSP.bat iMX7 Sabre_iMX7D_1GB
     </NMakeBuildCommandLine>
@@ -68,12 +68,12 @@
       call ..\..\..\tools\BuildBSP.bat iMX6 HummingBoardEdge_iMX6DL_1GB
       call ..\..\..\tools\BuildBSP.bat iMX6 HummingBoardEdge_iMX6Q_2GB
       call ..\..\..\tools\BuildBSP.bat iMX6 HummingBoardEdge_iMX6S_512MB
-      call ..\..\..\tools\BuildBSP.bat iMX6 RSB4411_iMX6Q_1GB
+      REM call ..\..\..\tools\BuildBSP.bat iMX6 RSB4411_iMX6Q_1GB
       call ..\..\..\tools\BuildBSP.bat iMX6 Sabre_iMX6Q_1GB
       call ..\..\..\tools\BuildBSP.bat iMX6 Sabre_iMX6QP_1GB
-      call ..\..\..\tools\BuildBSP.bat iMX6 SabreLite_iMX6Q_1GB
+      REM call ..\..\..\tools\BuildBSP.bat iMX6 SabreLite_iMX6Q_1GB
       call ..\..\..\tools\BuildBSP.bat iMX6 UdooNeo_iMX6SX_1GB
-      call ..\..\..\tools\BuildBSP.bat iMX6 VAB820_iMX6Q_1GB
+      REM call ..\..\..\tools\BuildBSP.bat iMX6 VAB820_iMX6Q_1GB
       call ..\..\..\tools\BuildBSP.bat iMX7 ClSomImx7_iMX7D_1GB
       call ..\..\..\tools\BuildBSP.bat iMX7 Sabre_iMX7D_1GB
     </NMakeReBuildCommandLine>


### PR DESCRIPTION
Remove OEMInput flags that have been deprecated in Windows 10 IoT Core, version 1809.
Temporarily omit several boards from BSP generation until their firmware has been updated.
Update documentation for IoT ADK AddonKit usage.