### PR TITLE
docs: specify branch of optee_os in firmware build docs

### DIFF
--- a/Documentation/build-firmware.md
+++ b/Documentation/build-firmware.md
@@ -27,7 +27,7 @@ This document describes how to set up a build environment to build the latest fi
     ```bash
     $ git clone --recursive https://github.com/ms-iot/imx-iotcore.git
     $ git clone --recursive -b u-boot-imx https://github.com/ms-iot/u-boot.git
-    $ git clone https://github.com/ms-iot/optee_os.git
+    $ git clone -b ms-iot https://github.com/ms-iot/optee_os.git
     $ git clone --recursive -b tcps-feature https://github.com/Microsoft/RIoT.git
     $ git clone https://github.com/ms-iot/imx-edk2-platforms.git
     $ git clone --recursive https://github.com/tianocore/edk2


### PR DESCRIPTION
This change is in response to customer question. I'm aware that the default branch will get pulled down but it's helpful to see in the documentation which branch that is. And with ongoing work in optee_os we may end up changing the default branch.