### PR TITLE
Specify edk2-platforms branch in firmware docs

### DIFF
--- a/Documentation/build-firmware.md
+++ b/Documentation/build-firmware.md
@@ -29,7 +29,7 @@ This document describes how to set up a build environment to build the latest fi
     $ git clone --recursive -b u-boot-imx https://github.com/ms-iot/u-boot.git
     $ git clone -b ms-iot https://github.com/ms-iot/optee_os.git
     $ git clone --recursive -b tcps-feature https://github.com/Microsoft/RIoT.git
-    $ git clone https://github.com/ms-iot/imx-edk2-platforms.git
+    $ git clone -b imx https://github.com/ms-iot/imx-edk2-platforms.git
     $ git clone --recursive https://github.com/tianocore/edk2
     $ git clone --recursive https://github.com/Microsoft/ms-tpm-20-ref
     ```


### PR DESCRIPTION
Possible branch confusion between `imx` and `master` branches in imx-edk2-platforms. Clarify to use the `imx` branch for this project. `master` branch is for tracking TianoCore's master branch.