### PR TITLE
fix arm64 build error for imxuart on build server

### DIFF
--- a/driver/serial/imxuart/imxuart.vcxproj
+++ b/driver/serial/imxuart/imxuart.vcxproj
@@ -135,6 +135,8 @@
     <ClCompile Include="..\..\shared\acpi\acpiutil.cpp">
       <WppEnabled Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">true</WppEnabled>
       <WppEnabled Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">true</WppEnabled>
+      <WppEnabled Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">true</WppEnabled>
+      <WppEnabled Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">true</WppEnabled>
     </ClCompile>
     <ClCompile Include="@(ClSourceFiles)" Exclude="@(ClCompile)">
       <WppEnabled>true</WppEnabled>


### PR DESCRIPTION
- Missed a small change for ARM64 for the imxuart driver in the vcxproj file.