### PR TITLE
mx6pep: fail initialization on non-IMX6 chips

### DIFF
--- a/driver/power/imx6pep/sys/mx6dpm.cpp
+++ b/driver/power/imx6pep/sys/mx6dpm.cpp
@@ -16,7 +16,6 @@
 #include "trace.h"
 #include "mx6dpm.tmh"
 
-#include <ImxCpuRev.h>
 #include "mx6powerdef.h"
 #include "mx6peputil.h"
 #include "mx6pepioctl.h"

--- a/driver/power/imx6pep/sys/precomp.h
+++ b/driver/power/imx6pep/sys/precomp.h
@@ -8,3 +8,4 @@
 #include <initguid.h>
 #include <ntstrsafe.h>
 #include <imxuarthw.h>
+#include <ImxCpuRev.h>


### PR DESCRIPTION
If imx6pep is loaded on a non-IMX6 device, fail driver initialization
to avoid a crash in IMX7 UpdateOS.

Related to #31 