### PR TITLE
Update TPM clone command to specific commit

### DIFF
--- a/Documentation/build-arm64-firmware.md
+++ b/Documentation/build-arm64-firmware.md
@@ -36,7 +36,7 @@ This document describes how to set up a build environment to build the latest fi
     Optionally, clone the TPM reference implementation (`mu_platform_nxp` includes a precompiled TPM binary)
     ```bash
     $ git clone --recursive https://github.com/Microsoft/ms-tpm-20-ref
-    $ pushd .; cd .\ms-tpm-20-ref; git checkout 65b65354c6cce3212d9c512ec3ae2e23fe37c94d; popd
+    $ pushd ms-tpm-20-ref; git checkout 65b65354c6cce3212d9c512ec3ae2e23fe37c94d; popd
     ```
 
 1) Download and extract the [Code Signing Tools (CST)](https://www.nxp.com/webapp/sps/download/license.jsp?colCode=IMX_CST_TOOL) from NXP's website. You will need to create an account on NXP's website to access this tool. Extract the tool to the same directory as all the above repositories, and rename the folder to cst:

--- a/Documentation/build-arm64-firmware.md
+++ b/Documentation/build-arm64-firmware.md
@@ -34,6 +34,12 @@ This document describes how to set up a build environment to build the latest fi
     $ git clone -b imx_4.14.62_1.0.0_beta https://source.codeaurora.org/external/imx/imx-atf
     $ git clone -b imx_4.14.62_1.0.0_beta https://source.codeaurora.org/external/imx/imx-mkimage
     ```
+    Optionally, clone the TPM reference implementation (`mu_platform_nxp` includes a copy of the TPM already)
+    ```bash
+    $ git clone --recursive https://github.com/Microsoft/ms-tpm-20-ref
+    $ git clone --recursive https://github.com/Microsoft/ms-tpm-20-ref
+    $ pushd .; cd .\ms-tpm-20-ref; git checkout 65b65354c6cce3212d9c512ec3ae2e23fe37c94d; popd
+    ```
 
 1) Download and extract the [Code Signing Tools (CST)](https://www.nxp.com/webapp/sps/download/license.jsp?colCode=IMX_CST_TOOL) from NXP's website. You will need to create an account on NXP's website to access this tool. Extract the tool to the same directory as all the above repositories, and rename the folder to cst:
     ```bash

--- a/Documentation/build-arm64-firmware.md
+++ b/Documentation/build-arm64-firmware.md
@@ -33,7 +33,7 @@ This document describes how to set up a build environment to build the latest fi
     $ git clone -b imx_4.14.62_1.0.0_beta https://source.codeaurora.org/external/imx/imx-atf
     $ git clone -b imx_4.14.62_1.0.0_beta https://source.codeaurora.org/external/imx/imx-mkimage
     ```
-    Optionally, clone the TPM reference implementation (`mu_platform_nxp` includes a copy of the TPM already)
+    Optionally, clone the TPM reference implementation (`mu_platform_nxp` includes a precompiled TPM binary)
     ```bash
     $ git clone --recursive https://github.com/Microsoft/ms-tpm-20-ref
     $ pushd .; cd .\ms-tpm-20-ref; git checkout 65b65354c6cce3212d9c512ec3ae2e23fe37c94d; popd

--- a/Documentation/build-arm64-firmware.md
+++ b/Documentation/build-arm64-firmware.md
@@ -30,13 +30,11 @@ This document describes how to set up a build environment to build the latest fi
     $ git clone --recursive -b imx_v2018.03_4.14.62_1.0.0_beta https://github.com/ms-iot/u-boot.git
     $ git clone -b codeaurora/imx_4.14.62_1.0.0_beta https://github.com/ms-iot/optee_os.git
     $ git clone --recursive https://github.com/ms-iot/mu_platform_nxp
-    $ git clone --recursive https://github.com/Microsoft/ms-tpm-20-ref
     $ git clone -b imx_4.14.62_1.0.0_beta https://source.codeaurora.org/external/imx/imx-atf
     $ git clone -b imx_4.14.62_1.0.0_beta https://source.codeaurora.org/external/imx/imx-mkimage
     ```
     Optionally, clone the TPM reference implementation (`mu_platform_nxp` includes a copy of the TPM already)
     ```bash
-    $ git clone --recursive https://github.com/Microsoft/ms-tpm-20-ref
     $ git clone --recursive https://github.com/Microsoft/ms-tpm-20-ref
     $ pushd .; cd .\ms-tpm-20-ref; git checkout 65b65354c6cce3212d9c512ec3ae2e23fe37c94d; popd
     ```

--- a/Documentation/build-firmware.md
+++ b/Documentation/build-firmware.md
@@ -32,7 +32,7 @@ This document describes how to set up a build environment to build the latest fi
     $ git clone -b imx https://github.com/ms-iot/imx-edk2-platforms.git
     $ git clone --recursive https://github.com/tianocore/edk2
     ```
-    Optionally, clone the TPM reference implementation (`imx-edk2-platforms` includes a copy of the TPM already)
+    Optionally, clone the TPM reference implementation (`imx-edk2-platforms` includes a precompiled TPM binary)
     ```bash
     $ git clone --recursive https://github.com/Microsoft/ms-tpm-20-ref
     $ pushd .; cd .\ms-tpm-20-ref; git checkout 65b65354c6cce3212d9c512ec3ae2e23fe37c94d; popd

--- a/Documentation/build-firmware.md
+++ b/Documentation/build-firmware.md
@@ -31,7 +31,11 @@ This document describes how to set up a build environment to build the latest fi
     $ git clone --recursive -b tcps-feature https://github.com/Microsoft/RIoT.git
     $ git clone -b imx https://github.com/ms-iot/imx-edk2-platforms.git
     $ git clone --recursive https://github.com/tianocore/edk2
+    ```
+    Optionally, clone the TPM reference implementation (`imx-edk2-platforms` includes a copy of the TPM already)
+    ```bash
     $ git clone --recursive https://github.com/Microsoft/ms-tpm-20-ref
+    $ pushd .; cd .\ms-tpm-20-ref; git checkout 65b65354c6cce3212d9c512ec3ae2e23fe37c94d; popd
     ```
 
 1) Download and extract the [Code Signing Tools (CST)](https://www.nxp.com/webapp/sps/download/license.jsp?colCode=IMX_CST_TOOL) from NXP's website. You will need to create an account on NXP's website to access this tool. Extract the tool to the same directory as all the above repositories, and rename the folder to cst:

--- a/Documentation/build-firmware.md
+++ b/Documentation/build-firmware.md
@@ -35,7 +35,7 @@ This document describes how to set up a build environment to build the latest fi
     Optionally, clone the TPM reference implementation (`imx-edk2-platforms` includes a precompiled TPM binary)
     ```bash
     $ git clone --recursive https://github.com/Microsoft/ms-tpm-20-ref
-    $ pushd .; cd .\ms-tpm-20-ref; git checkout 65b65354c6cce3212d9c512ec3ae2e23fe37c94d; popd
+    $ pushd ms-tpm-20-ref; git checkout 65b65354c6cce3212d9c512ec3ae2e23fe37c94d; popd
     ```
 
 1) Download and extract the [Code Signing Tools (CST)](https://www.nxp.com/webapp/sps/download/license.jsp?colCode=IMX_CST_TOOL) from NXP's website. You will need to create an account on NXP's website to access this tool. Extract the tool to the same directory as all the above repositories, and rename the folder to cst:


### PR DESCRIPTION
The reference implementation is being updated regularly, indicate that the TPM is an optional component. Also indicate a known good commit to checkout.