### PR TITLE
Add Python3 tools to build firmware docs

### DIFF
--- a/Documentation/build-firmware.md
+++ b/Documentation/build-firmware.md
@@ -15,7 +15,7 @@ This document describes how to set up a build environment to build the latest fi
     ```bash
     $ sudo apt-get update
     $ sudo apt-get upgrade
-    $ sudo apt-get install build-essential python python-dev python-crypto python-wand device-tree-compiler bison flex swig iasl uuid-dev wget git bc libssl-dev
+    $ sudo apt-get install build-essential python python-dev python-crypto python-wand device-tree-compiler bison flex swig iasl uuid-dev wget git bc libssl-dev python3-setuptools python3
     $ pushd ~
     $ wget https://releases.linaro.org/components/toolchain/binaries/6.4-2017.11/arm-linux-gnueabihf/gcc-linaro-6.4.1-2017.11-x86_64_arm-linux-gnueabihf.tar.xz
     $ tar xf gcc-linaro-6.4.1-2017.11-x86_64_arm-linux-gnueabihf.tar.xz


### PR DESCRIPTION
EDK2 moved their BaseTools to Python3. We must add Python3 tools to our initial apt-get install