### PR TITLE
Update Authvars crypto flag name to be consistent

### DIFF
--- a/Documentation/build-firmware.md
+++ b/Documentation/build-firmware.md
@@ -131,7 +131,7 @@ Copy `uefi.fit` over to the EFI partition on your SD card.
 ### Updating the TAs in UEFI
 A firmware TPM TA, and UEFI authenticated variable TA, are included with EDK2. Generally, these TAs should work on any ARM32 system where OP-TEE is running, and eMMC RPMB is available.
 
-These binaries are built using OpenSSL by default but can also be built using WolfSSL (See `FTPM_FLAGS` and `AUTHVAR_FLAGS` in `common.mk`).
+These binaries are built using OpenSSL by default but can also be built using WolfSSL (See `FTPM_FLAGS` and `AUTHVARS_FLAGS` in `common.mk`).
 
 They are omitted from the firmware if the `CONFIG_NOT_SECURE_UEFI=1` flag is set. This is useful for early development work if RPMB storage is not functioning yet, or if eMMC is not pressent on the device.
 

--- a/build/firmware/Common.mk
+++ b/build/firmware/Common.mk
@@ -53,8 +53,8 @@ FTPM_FLAGS= \
 	CFG_TEE_TA_LOG_LEVEL=2 \
 	CFG_TA_DEBUG=n \
 
-AUTHVAR_FLAGS= \
-	$(AUTHVAR_CRYPTO_PROVIDER) \
+AUTHVARS_FLAGS= \
+	$(AUTHVARS_CRYPTO_PROVIDER) \
 	CFG_TEE_TA_LOG_LEVEL=2 \
 	CFG_TA_DEBUG=n \
 
@@ -287,7 +287,7 @@ authvars: optee
 	echo "TA directory $(abspath $(TA_ROOT)) not found" ; \
 	exit 1 ; \
 	fi
-	$(MAKE) -C $(TA_ROOT) TA_CPU=cortex-a9 O=$(AUTHVARS_OUT) $(AUTHVAR_FLAGS) authvars
+	$(MAKE) -C $(TA_ROOT) TA_CPU=cortex-a9 O=$(AUTHVARS_OUT) $(AUTHVARS_FLAGS) authvars
 	cp -f $(AUTHVARS_OUT)/2d57c0f7-bddf-48ea-832f-d84a1a219301.elf $(AUTHVARS_BIN_PLACE)
 	cp -f $(AUTHVARS_OUT)/2d57c0f7-bddf-48ea-832f-d84a1a219301.ta $(AUTHVARS_BIN_PLACE)
 


### PR DESCRIPTION
There was a mismatch between AUTHVAR**S**_CRYPTO_PROVIDER and AUTHVAR_CRYPTO_PROVIDER