### PR TITLE
Repurpose make update-ffu. Add make commit-ffu

### DIFF
--- a/Documentation/build-firmware.md
+++ b/Documentation/build-firmware.md
@@ -90,11 +90,15 @@ This document describes how to set up a build environment to build the latest fi
 1) To make the updated firmware a part of your FFU build, you must copy the firmwares to your board's Package folder in imx-iotcore.
  * Copy uefi.fit into /board/boardname/Package/BootFirmware
  * Copy firmware_fit.merged into /board/boardname/Package/BootLoader
+ * You can also use the following make command to copy uefi.fit and firmware_fit.merged to the correct package directories.
+    ```bash
+    $ make update-ffu
+    ```
 
 2) When preparing to commit your changes, you should use the following make command save your OP-TEE SDK and the commit versions of your firmware automatically in your board folder.
 
     ```bash
-    $ make update-ffu
+    $ make commit-firmware
     ```
 
 ## Deploying firmware to an SD card manually

--- a/Documentation/build-firmware.md
+++ b/Documentation/build-firmware.md
@@ -95,7 +95,7 @@ This document describes how to set up a build environment to build the latest fi
     $ make update-ffu
     ```
 
-2) When preparing to commit your changes, you should use the following make command save your OP-TEE SDK and the commit versions of your firmware automatically in your board folder.
+2) When preparing to commit your changes, you should use the following make command to save your OP-TEE SDK and the commit versions of your firmware automatically in your board folder.
 
     ```bash
     $ make commit-firmware

--- a/build/firmware/Common.mk
+++ b/build/firmware/Common.mk
@@ -291,9 +291,18 @@ authvars: optee
 	cp -f $(AUTHVARS_OUT)/2d57c0f7-bddf-48ea-832f-d84a1a219301.elf $(AUTHVARS_BIN_PLACE)
 	cp -f $(AUTHVARS_OUT)/2d57c0f7-bddf-48ea-832f-d84a1a219301.ta $(AUTHVARS_BIN_PLACE)
 
-# Copy binaries from build output to package location and 'git add' them
+# Copy binaries from build output to package location
 .PHONY: update-ffu
-update-ffu: $(VERSIONS)
+update-ffu:
+	board=`basename $$PWD` && \
+	dest=../../board/$$board/Package/BootLoader && \
+	uefidest=../../board/$$board/Package/BootFirmware && \
+	cp firmware_fit.merged $$dest && \
+	cp uefi.fit $$uefidest
+
+# Copy binaries from build output to package location and 'git add' them
+.PHONY: commit-firmware
+commit-firmware: $(VERSIONS)
 	board=`basename $$PWD` && \
 	dest=../../board/$$board/Package/BootLoader && \
 	uefidest=../../board/$$board/Package/BootFirmware && \

--- a/build/firmware/Makefile
+++ b/build/firmware/Makefile
@@ -16,6 +16,7 @@ BOARDS=\
 	EVK_iMX6ULL_512MB \
 
 UPDATEDIRS=$(BOARDS:%=update-%)
+COMMITDIRS=$(BOARDS:%=commit-%)
 CLEANDIRS=$(BOARDS:%=clean-%)
 
 all: $(BOARDS)
@@ -25,6 +26,10 @@ $(BOARDS):
 update-ffu: $(UPDATEDIRS)
 $(UPDATEDIRS):
 	$(MAKE) -C $(@:update-%=%) update-ffu
+
+commit-firmware: $(COMMITDIRS)
+$(COMMITDIRS):
+	$(MAKE) -C $(@:commit-%=%) commit-firmware
 
 clean: $(CLEANDIRS)
 $(CLEANDIRS):
@@ -40,4 +45,4 @@ print_board_list:
 .PHONY: subdirs $(BOARDS)
 .PHONY: subdirs $(UPDATEDIRS)
 .PHONY: subdirs $(CLEANDIRS)
-.PHONY: all update-ffu clean
+.PHONY: all update-ffu commit-ffu clean


### PR DESCRIPTION
Since we already have a make command to move firmware_fit.merged and
uefi.fit to the correct directories from the firmware build directories
we should have a version that does that without any git operations.