### PR TITLE
Add imx8 components

### DIFF
--- a/build/firmware/CGManifests.mk
+++ b/build/firmware/CGManifests.mk
@@ -22,7 +22,7 @@
 #		make <REPO_NAME>_cgmanifest_nodep
 
 # List of all repos to generate dependencies for:
-CG_MANIFEST_REPOS= imx-iotcore u-boot optee_os RIoT imx-edk2-platforms MSRSec mu_platform_nxp
+CG_MANIFEST_REPOS= imx-iotcore u-boot optee_os RIoT imx-edk2-platforms MSRSec mu_platform_nxp edk2
 
 # CG Manifest dependency Graph. List all implicit dependencies here. Submodules will be detected
 # automatically.
@@ -32,7 +32,7 @@ CG_MANIFEST_REPOS= imx-iotcore u-boot optee_os RIoT imx-edk2-platforms MSRSec mu
 imx-iotcore_cgmanifest_deps=u-boot optee_os imx-edk2-platforms mu_platform_nxp
 u-boot_cgmanifest_deps=RIoT
 optee_os_cgmanifest_deps=
-imx-edk2-platforms_cgmanifest_deps=MSRSec
+imx-edk2-platforms_cgmanifest_deps=MSRSec edk2
 RIoT_cgmanifest_deps=
 edk2_cgmanifest_deps=
 MSRSec_cgmanifest_deps=

--- a/build/firmware/CGManifests.mk
+++ b/build/firmware/CGManifests.mk
@@ -22,7 +22,18 @@
 #		make <REPO_NAME>_cgmanifest_nodep
 
 # List of all repos to generate dependencies for:
-CG_MANIFEST_REPOS= imx-iotcore u-boot optee_os RIoT imx-edk2-platforms MSRSec mu_platform_nxp edk2
+CG_MANIFEST_REPOS= imx-iotcore u-boot optee_os RIoT imx-edk2-platforms MSRSec edk2
+
+# Add project MU, the MU submodules may themselves include other submodules
+MU_DEPENDENCIES = mu_platform_nxp \
+ mu_platform_nxp/Common/MU \
+ mu_platform_nxp/Common/MU_OEM_SAMPLE \
+ mu_platform_nxp/Common/MU_TIANO \
+ mu_platform_nxp/MU_BASECORE \
+ mu_platform_nxp/Silicon/ARM/MU_TIANO \
+ mu_platform_nxp/Silicon/ARM/NXP
+
+CG_MANIFEST_REPOS+= $(MU_DEPENDENCIES)
 
 # CG Manifest dependency Graph. List all implicit dependencies here. Submodules will be detected
 # automatically.
@@ -33,6 +44,7 @@ imx-iotcore_cgmanifest_deps=u-boot optee_os imx-edk2-platforms mu_platform_nxp
 u-boot_cgmanifest_deps=RIoT
 optee_os_cgmanifest_deps=
 imx-edk2-platforms_cgmanifest_deps=MSRSec edk2
+mu_platform_nxp_cgmanifest_deps= $(MU_DEPENDENCIES)
 RIoT_cgmanifest_deps=
 edk2_cgmanifest_deps=
 MSRSec_cgmanifest_deps=

--- a/build/firmware/CGManifests.mk
+++ b/build/firmware/CGManifests.mk
@@ -22,14 +22,14 @@
 #		make <REPO_NAME>_cgmanifest_nodep
 
 # List of all repos to generate dependencies for:
-CG_MANIFEST_REPOS= imx-iotcore u-boot optee_os RIoT imx-edk2-platforms MSRSec
+CG_MANIFEST_REPOS= imx-iotcore u-boot optee_os RIoT imx-edk2-platforms MSRSec mu_platform_nxp
 
 # CG Manifest dependency Graph. List all implicit dependencies here. Submodules will be detected
 # automatically.
 #
 # It should not be necessary to list pure upstream repos (edk2, etc) here, it is expected that
 # they will have properly attributed all of their componenets already.
-imx-iotcore_cgmanifest_deps=u-boot optee_os imx-edk2-platforms
+imx-iotcore_cgmanifest_deps=u-boot optee_os imx-edk2-platforms mu_platform_nxp
 u-boot_cgmanifest_deps=RIoT
 optee_os_cgmanifest_deps=
 imx-edk2-platforms_cgmanifest_deps=MSRSec

--- a/ci/cgmanifest.json
+++ b/ci/cgmanifest.json
@@ -40,6 +40,42 @@
             "component": {
                 "type": "git",
                 "git": {
+                    "repositoryUrl": "https://github.com/ms-iot/u-boot.git",
+                    "commitHash": "63f552fac5c8070c4451bdf81cf7b1a3158b07d2"
+                }
+            }
+        },
+        {
+            "component": {
+                "type": "git",
+                "git": {
+                    "repositoryUrl": "https://github.com/ms-iot/optee_os.git",
+                    "commitHash": "7edb46e0fe60261d06bb2390b716201d6772e16f"
+                }
+            }
+        },
+        {
+            "component": {
+                "type": "git",
+                "git": {
+                    "repositoryUrl": "https://source.codeaurora.org/external/imx/imx-atf",
+                    "commitHash": "413e93e10ee4838e9a68b190f1468722f6385e0e"
+                }
+            }
+        },
+        {
+            "component": {
+                "type": "git",
+                "git": {
+                    "repositoryUrl": "https://github.com/ms-iot/mu_platform_nxp",
+                    "commitHash": "da89fdfbcd70f56be7e815fc5a842e13f0f38815"
+                }
+            }
+        },
+        {
+            "component": {
+                "type": "git",
+                "git": {
                     "repositoryUrl": "https://github.com/intel/tinycbor.git",
                     "commitHash": "aa3731592c784ce91e7fcafa66665c147b18be25"
                 }
@@ -96,6 +132,69 @@
                 "git": {
                     "repositoryUrl": "https://github.com/wolfSSL/wolfssl.git",
                     "commitHash": "74ebf510a3d73e98767eac26082eabdc84e19d31"
+                }
+            }
+        },
+        {
+            "component": {
+                "type": "git",
+                "git": {
+                    "repositoryUrl": "https://github.com/openssl/openssl",
+                    "commitHash": "74f2d9c1ec5f5510e1d3da5a9f03c28df0977762"
+                }
+            }
+        },
+        {
+            "component": {
+                "type": "git",
+                "git": {
+                    "repositoryUrl": "https://github.com/Microsoft/mu_plus.git",
+                    "commitHash": "6fe8e0cec25434c9e746e306cda885801a7141bc"
+                }
+            }
+        },
+        {
+            "component": {
+                "type": "git",
+                "git": {
+                    "repositoryUrl": "https://github.com/Microsoft/mu_oem_sample.git",
+                    "commitHash": "bc8add5ffc85943393887349125509583756355c"
+                }
+            }
+        },
+        {
+            "component": {
+                "type": "git",
+                "git": {
+                    "repositoryUrl": "https://github.com/Microsoft/mu_tiano_plus.git",
+                    "commitHash": "c6a0ad30012bae30fb9bb06e9b3caa975ac631a7"
+                }
+            }
+        },
+        {
+            "component": {
+                "type": "git",
+                "git": {
+                    "repositoryUrl": "https://github.com/Microsoft/mu_basecore.git",
+                    "commitHash": "97b39c0a8a7fb9d949310f93615835891862f7b0"
+                }
+            }
+        },
+        {
+            "component": {
+                "type": "git",
+                "git": {
+                    "repositoryUrl": "https://github.com/Microsoft/mu_silicon_arm_tiano.git",
+                    "commitHash": "6c366af7a3772450cb137faa50656f77f204e4b1"
+                }
+            }
+        },
+        {
+            "component": {
+                "type": "git",
+                "git": {
+                    "repositoryUrl": "https://github.com/ms-iot/MU_SILICON_NXP.git",
+                    "commitHash": "65fae2fc9d1cbe6ccebed4a0b5a9b119ba0d37c5"
                 }
             }
         },

--- a/ci/cgmanifest_template.json
+++ b/ci/cgmanifest_template.json
@@ -35,6 +35,42 @@
                     "branch": "imx"
                 }
             }
+        },
+        {
+            "component": {
+                "type": "git",
+                "git": {
+                    "repositoryUrl": "https://github.com/ms-iot/u-boot.git",
+                    "branch": "imx_v2018.03_4.14.98_2.0.0_ga"
+                }
+            }
+        },
+        {
+            "component": {
+                "type": "git",
+                "git": {
+                    "repositoryUrl": "https://github.com/ms-iot/optee_os.git",
+                    "branch": "imx_4.14.98_2.0.0_ga"
+                }
+            }
+        },
+        {
+            "component": {
+                "type": "git",
+                "git": {
+                    "repositoryUrl": "https://source.codeaurora.org/external/imx/imx-atf",
+                    "branch": "imx_4.14.98_2.0.0_ga"
+                }
+            }
+        },
+        {
+            "component": {
+                "type": "git",
+                "git": {
+                    "repositoryUrl": "https://github.com/ms-iot/mu_platform_nxp",
+                    "branch": "master"
+                }
+            }
         }
     ],
     "Version": 1


### PR DESCRIPTION
Scan for additional MU dependencies.

The OSSL version in use by MU is the same as EDK2 so no additional registration is needed for now.