### PR TITLE
Update CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-*   @ms-iot-silicon-codeowners @mvarecha
+*   @ms-iot/ms-iot-silicon-codeowners @mvarecha


### PR DESCRIPTION
To add teams to codeowners file, you must add the organization in front of the team name.