### PR TITLE
Improve case sensitivity handling

### DIFF
--- a/build/firmware/Common.mk
+++ b/build/firmware/Common.mk
@@ -384,6 +384,7 @@ $(OPTEE): verify_case_sensitivity_$(OPTEE_OUT)
 verify_case_sensitivity: verify_case_sensitivity_$(UBOOT_OUT) verify_case_sensitivity_$(OPTEE_OUT)
 CASE_DIR=$(subst verify_case_sensitivity_,,$@)
 CASE_DIR_WIN=$(shell wslpath -m $(CASE_DIR))
+CASE_WSL_MNT=$(CASE_DIR:/mnt/%=)
 CASE_SENSITIVITY_CMD=fsutil.exe file queryCaseSensitiveInfo $(CASE_DIR_WIN) | grep -o
 MOUNT_BASE_DIRECTORY=$(shell echo $(CASE_DIR) | cut -d "/" -f1-3)
 MOUNT_CASE_SENSITIVITY_CMD=mount | grep "$(MOUNT_BASE_DIRECTORY)" | grep -o
@@ -392,6 +393,9 @@ IS_ADMIN_CMD=net.exe session 2>&1 >/dev/null | grep -o
 verify_case_sensitivity_$(UBOOT_OUT) verify_case_sensitivity_$(OPTEE_OUT):
 ifeq (,$(findstring Microsoft,$(shell cat /proc/sys/kernel/osrelease)))
 	@echo Not running WSL, no case sensitivity check needed.
+else
+ifneq (,$(CASE_WSL_MNT))
+	@echo Running WSL, but not in a mount.
 else
 	@echo Checking case sensitivity of $(CASE_DIR)
 	mkdir -p $(CASE_DIR)
@@ -418,7 +422,8 @@ else
 	  echo Setting case sensitivity enabled on $(CASE_DIR)
 	  fsutil.exe file setCaseSensitiveInfo . enable
 	fi
-endif
+endif #Not WSL mount
+endif #Not WSL
 
 .PHONY: clean
 clean:

--- a/build/firmware/Common.mk
+++ b/build/firmware/Common.mk
@@ -384,7 +384,7 @@ $(OPTEE): verify_case_sensitivity_$(OPTEE_OUT)
 verify_case_sensitivity: verify_case_sensitivity_$(UBOOT_OUT) verify_case_sensitivity_$(OPTEE_OUT)
 CASE_DIR=$(subst verify_case_sensitivity_,,$@)
 CASE_DIR_WIN=$(shell wslpath -m $(CASE_DIR))
-CASE_WSL_MNT=$(CASE_DIR:/mnt/%=)
+CASE_WSL_MNT=$(UBOOT_OUT:/mnt/%=) # Need to statically check this, rather than use $@
 CASE_SENSITIVITY_CMD=fsutil.exe file queryCaseSensitiveInfo $(CASE_DIR_WIN) | grep -o
 MOUNT_BASE_DIRECTORY=$(shell echo $(CASE_DIR) | cut -d "/" -f1-3)
 MOUNT_CASE_SENSITIVITY_CMD=mount | grep "$(MOUNT_BASE_DIRECTORY)" | grep -o

--- a/build/firmware/Makefile
+++ b/build/firmware/Makefile
@@ -18,10 +18,16 @@ BOARDS=\
 UPDATEDIRS=$(BOARDS:%=update-%)
 COMMITDIRS=$(BOARDS:%=commit-%)
 CLEANDIRS=$(BOARDS:%=clean-%)
+INITDIRS=$(BOARDS:%=init-%)
 
 all: $(BOARDS)
-$(BOARDS):
+$(BOARDS): init-dirs
 	$(MAKE) -C $@
+
+#Checks for the case sensitivity of all output folders all at once.
+init-dirs: $(INITDIRS)
+$(INITDIRS):
+	$(MAKE) -C $(@:init-%=%) verify_case_sensitivity
 
 update-ffu: $(UPDATEDIRS)
 $(UPDATEDIRS):
@@ -42,7 +48,5 @@ include CGManifests.mk
 print_board_list:
 	@echo $(BOARDS) | tr " " "\n"
 
-.PHONY: subdirs $(BOARDS)
-.PHONY: subdirs $(UPDATEDIRS)
-.PHONY: subdirs $(CLEANDIRS)
-.PHONY: all update-ffu commit-ffu clean
+.PHONY: $(BOARDS) $(INITDIRS) $(UPDATEDIRS) $(CLEANDIRS)
+.PHONY: all update-ffu commit-ffu clean init-dirs

--- a/build/firmware/Makefile
+++ b/build/firmware/Makefile
@@ -25,9 +25,12 @@ $(BOARDS): init-dirs
 	$(MAKE) -C $@
 
 #Checks for the case sensitivity of all output folders all at once.
-init-dirs: $(INITDIRS)
-$(INITDIRS):
-	$(MAKE) -C $(@:init-%=%) verify_case_sensitivity
+#Force serial build using $(foreach to avoid too many pop-ups which can cause some to fail.
+init-dirs:
+	$(foreach BOARD, $(INITDIRS), \
+	$(MAKE) -C $(BOARD:init-%=%) verify_case_sensitivity && \
+	sleep 1 && \
+	) true
 
 update-ffu: $(UPDATEDIRS)
 $(UPDATEDIRS):


### PR DESCRIPTION
* Should now only trigger a case sensitivity check when building out of a mounted directory in WSL
* When doing a `make all`, deal with all the case sensitivity checks right away.
* Add init-dirs to manually trigger the directory creation at any time