### PR TITLE
Add iMX8 build infrastructure

### DIFF
--- a/Documentation/build-arm64-firmware.md
+++ b/Documentation/build-arm64-firmware.md
@@ -71,7 +71,30 @@ Note: The UEFI build environment has changed for 1903 and any existing build env
        |- u-boot
       ```
 
-1) Build firmware to test the setup. Adding "-j 20" to make will parallelize the build and speed it up significantly on WSL, but since the firmwares build in parallel it will be more difficult to diagnose any build failures. You can customize the number to work best with your system.
+1) A makefile is available which automates the build process.
+    ```bash
+    cd imx-iotcore/build/firmware
+    # Build firmware components for a specific board, but don't update the packages
+    make -f imx8.mk IMX8_TARGET=NXPEVK_iMX8M_4GB CROSS_COMPILE=~/gcc-linaro-7.2.1-2017.11-x86_64_aarch64-linux-gnu/bin/aarch64-linux-gnu- imx8_build
+    ```
+    To update the binaries in the FFU packages:
+    ```bash
+    cd imx-iotcore/build/firmware
+    # Build AND update the packages for a specific board
+    make -f imx8.mk IMX8_TARGET=NXPEVK_iMX8M_4GB CROSS_COMPILE=~/gcc-linaro-7.2.1-2017.11-x86_64_aarch64-linux-gnu/bin/aarch64-linux-gnu- imx8_update-ffu
+    ```
+    Build/update all i.MX8 boards:
+    ```bash
+    cd imx-iotcore/build/firmware
+    # Build each firmware (Note: will override the outputs)    
+    make imx8_all
+    # Update the firmware binaries in the package folders (requires re-build)
+    make imx8_update-ffu
+    # Stage the firmware for a commit (requires re-build)
+    make imx8_commit-firmware
+    ```
+
+1) Manually build the firmware to test the setup. Adding "-j 20" to make will parallelize the build and speed it up significantly on WSL, but since the firmwares build in parallel it will be more difficult to diagnose any build failures. You can customize the number to work best with your system.
 
     ```bash
    # U-Boot

--- a/build/firmware/Makefile
+++ b/build/firmware/Makefile
@@ -1,6 +1,6 @@
 # This Makefile inspired by http://lackof.org/taggart/hacking/make-example/
 
-BOARDS=\
+IMX67_BOARDS=\
 	ClSomImx7_iMX7D_1GB \
 	HummingBoardEdge_iMX6DL_1GB \
 	HummingBoardEdge_iMX6Q_2GB \
@@ -11,18 +11,41 @@ BOARDS=\
 	Sabre_iMX7D_1GB \
 	SabreLite_iMX6Q_1GB \
 	UdooNeo_iMX6SX_1GB \
-	NXPEVK_iMX8M_4GB \
 	VAB820_iMX6Q_1GB \
 	EVK_iMX6ULL_512MB \
 
-UPDATEDIRS=$(BOARDS:%=update-%)
-COMMITDIRS=$(BOARDS:%=commit-%)
-CLEANDIRS=$(BOARDS:%=clean-%)
-INITDIRS=$(BOARDS:%=init-%)
+IMX8_BOARDS=\
+	NXPEVK_iMX8M_4GB \
+	NXPEVK_iMX8M_Mini_2GB \
 
-all: $(BOARDS)
-$(BOARDS): init-dirs
+UPDATEDIRS=$(IMX67_BOARDS:%=update-%)
+COMMITDIRS=$(IMX67_BOARDS:%=commit-%)
+CLEANDIRS=$(IMX67_BOARDS:%=clean-%)
+INITDIRS=$(IMX67_BOARDS:%=init-%)
+
+#Serialize since some builds are mutually exclusive (imx8, EKD2)
+# serialize_builds(command, common arguments, serialized list)
+define serialize_builds
+	$(foreach PARAM, $3, \
+	$1 $2 $(PARAM) && \
+	) true
+endef
+
+all: imx67_boards_serialized
+imx8_all: imx8_boards_serialized
+
+#Allows for a call to specific boards ie: "make NXPEVK_iMX8M_4GB", but will not enforce serialization of the builds
+$(IMX67_BOARDS):
 	$(MAKE) -C $@
+
+$(IMX8_BOARDS):
+	$(MAKE) imx8_build IMX8_TARGET=$@
+
+imx67_boards_serialized: #init-dirs
+	$(call serialize_builds,$(MAKE),-C,$(foreach BOARD,$(IMX67_BOARDS),$(BOARD)))
+
+imx8_boards_serialized:
+	$(call serialize_builds,$(MAKE) -f imx8.mk, imx8_build, $(foreach BOARD,$(IMX8_BOARDS),IMX8_TARGET=$(BOARD)))
 
 #Checks for the case sensitivity of all output folders all at once.
 #Force serial build using $(foreach to avoid too many pop-ups which can cause some to fail.
@@ -36,9 +59,17 @@ update-ffu: $(UPDATEDIRS)
 $(UPDATEDIRS):
 	$(MAKE) -C $(@:update-%=%) update-ffu
 
+#IMX8 requires a re-build to do this.
+imx8_update-ffu:
+	$(call serialize_builds,$(MAKE) -f imx8.mk, imx8_update-ffu, $(foreach BOARD,$(IMX8_BOARDS),IMX8_TARGET=$(BOARD)))
+
 commit-firmware: $(COMMITDIRS)
 $(COMMITDIRS):
 	$(MAKE) -C $(@:commit-%=%) commit-firmware
+
+#IMX8 requires a re-build to do this.
+imx8_commit-firmware:
+	$(call serialize_builds, $(MAKE) -f imx8.mk, imx8_commit-firmware, $(foreach BOARD,$(IMX8_BOARDS),IMX8_TARGET=$(BOARD)))
 
 clean: $(CLEANDIRS)
 $(CLEANDIRS):
@@ -51,5 +82,6 @@ include CGManifests.mk
 print_board_list:
 	@echo $(BOARDS) | tr " " "\n"
 
-.PHONY: $(BOARDS) $(INITDIRS) $(UPDATEDIRS) $(CLEANDIRS)
-.PHONY: all update-ffu commit-ffu clean init-dirs
+.PHONY: $(IMX67_BOARDS) $(IMX8_BOARDS) $(INITDIRS) $(UPDATEDIRS) $(CLEANDIRS)
+.PHONY: all update-ffu commit-ffu clean init-dirs imx67_boards_serialized
+.PHONY: imx8_all imx8_update-ffu imx8_commit-firmware imx8_boards_serialized

--- a/build/firmware/imx8.mk
+++ b/build/firmware/imx8.mk
@@ -1,0 +1,144 @@
+.ONESHELL:
+SHELL = bash
+.SHELLFLAGS = -ec
+
+CROSS_COMPILE ?=$(HOME)/gcc-linaro-7.2.1-2017.11-x86_64_aarch64-linux-gnu/bin/aarch64-linux-gnu-
+ARCH=arm64
+VERSIONS=firmwareversions.log
+
+ifeq (,$(IMX8_TARGET))
+$(error IMX8_TARGET not set)
+endif
+
+ifeq ($(IMX8_TARGET),NXPEVK_iMX8M_4GB)
+U_BOOT_CONFIG=imx8mq_evk_nt_defconfig
+U_BOOT_DTS=fsl-imx8mq-evk
+U_BOOT_SOC=iMX8M
+ATF_CONFIG=imx8mq
+EDK2_PLATFORM=MCIMX8M_EVK_4GB
+OPTEE_PLATFORM=mx8mqevk
+endif
+
+ifeq ($(IMX8_TARGET),NXPEVK_iMX8M_Mini_2GB)
+U_BOOT_CONFIG=imx8mm_evk_nt_defconfig
+U_BOOT_DTS=fsl-imx8mm-evk
+U_BOOT_SOC=iMX8MM
+ATF_CONFIG=imx8mm
+EDK2_PLATFORM=MCIMX8M_MINI_EVK_2GB
+OPTEE_PLATFORM=mx8mmevk
+endif
+
+IMX8_REPO_ROOT?=$(abspath ../../../)
+
+.PHONY: imx8_u-boot imx8_optee imx8_atf imx8_uefi imx8_tas imx8_mkimage imx8_update-ffu imx8_build $(VERSIONS)
+
+imx8_u-boot:
+	cd $(IMX8_REPO_ROOT)/u-boot
+	export ARCH=$(ARCH)
+	export CROSS_COMPILE=$(CROSS_COMPILE)
+	
+	$(MAKE) $(U_BOOT_CONFIG) 
+	$(MAKE)
+	
+imx8_atf:
+	cd $(IMX8_REPO_ROOT)/imx-atf
+	export ARCH=$(ARCH)
+	export CROSS_COMPILE=$(CROSS_COMPILE)
+	rm -rf build
+	$(MAKE) PLAT=$(ATF_CONFIG) SPD=opteed bl31
+	
+imx8_optee:
+	cd $(IMX8_REPO_ROOT)/optee_os
+	$(MAKE) PLATFORM=imx PLATFORM_FLAVOR=$(OPTEE_PLATFORM) \
+     CFG_TEE_CORE_DEBUG=n CFG_TEE_CORE_LOG_LEVEL=2  CFG_UART_BASE=0x30890000 \
+     CFG_RPMB_FS=y CFG_RPMB_TESTKEY=y CFG_RPMB_WRITE_KEY=y CFG_REE_FS=n  \
+     CFG_IMXCRYPT=y CFG_CORE_HEAP_SIZE=98304 \
+	 CROSS_COMPILE64=$(CROSS_COMPILE) \
+	 CROSS_COMPILE= \
+	 
+	$(CROSS_COMPILE)objcopy -O binary ./out/arm-plat-imx/core/tee.elf ./out/arm-plat-imx/tee.bin
+	
+imx8_tas:
+	pushd $(IMX8_REPO_ROOT)/MSRSec/TAs/optee_ta
+	$(MAKE) -j1 CFG_ARM64_ta_arm64=y CFG_FTPM_USE_WOLF=y CFG_AUTHVARS_USE_WOLF=y CFG_TEE_TA_LOG_LEVEL=4 CFG_TA_DEBUG=y \
+	TA_DEV_KIT_DIR=../../../../optee_os/out/arm-plat-imx/export-ta_arm64 \
+	TA_CROSS_COMPILE=$(CROSS_COMPILE) \
+	TA_CPU=cortex-a53 \
+	
+	popd
+	cp $(IMX8_REPO_ROOT)/MSRSec/TAs/optee_ta/out/AuthVars/2d57c0f7-bddf-48ea-832f-d84a1a219301.ta  $(IMX8_REPO_ROOT)/mu_platform_nxp/Microsoft/OpteeClientPkg/Bin/AuthvarsTa/Arm64/Test/
+	cp $(IMX8_REPO_ROOT)/MSRSec/TAs/optee_ta/out/AuthVars/2d57c0f7-bddf-48ea-832f-d84a1a219301.elf $(IMX8_REPO_ROOT)/mu_platform_nxp/Microsoft/OpteeClientPkg/Bin/AuthvarsTa/Arm64/Test/
+	cp $(IMX8_REPO_ROOT)/MSRSec/TAs/optee_ta/out/fTPM/bc50d971-d4c9-42c4-82cb-343fb7f37896.ta $(IMX8_REPO_ROOT)/mu_platform_nxp/Microsoft/OpteeClientPkg/Bin/fTpmTa/Arm64/Test/
+	cp $(IMX8_REPO_ROOT)/MSRSec/TAs/optee_ta/out/fTPM/bc50d971-d4c9-42c4-82cb-343fb7f37896.elf $(IMX8_REPO_ROOT)/mu_platform_nxp/Microsoft/OpteeClientPkg/Bin/fTpmTa/Arm64/Test/
+
+IMX8_MKIMAGE_DEPS_DDR=$(wildcard $(IMX8_REPO_ROOT)/firmware-imx-8.1/firmware/ddr/synopsys/lpddr4_pmu_train_*.bin)
+IMX8_MKIMAGE_DEPS_HDMI=$(wildcard $(IMX8_REPO_ROOT)/firmware-imx-8.1/firmware/hdmi/cadence/signed_hdmi_imx8m.bin)
+IMX8_MKIMAGE_DEPS_OPTEE=$(IMX8_REPO_ROOT)/optee_os/out/arm-plat-imx/tee.bin
+IMX8_MKIMAGE_DEPS_ATF=$(IMX8_REPO_ROOT)/imx-atf/build/$(ATF_CONFIG)/release/bl31.bin
+IMX8_MKIMAGE_DEPS_U-BOOT=$(IMX8_REPO_ROOT)/u-boot/u-boot-nodtb.bin $(IMX8_REPO_ROOT)/u-boot/spl/u-boot-spl.bin $(IMX8_REPO_ROOT)/u-boot/arch/arm/dts/$(U_BOOT_DTS).dtb $(IMX8_REPO_ROOT)/u-boot/tools/mkimage
+imx8_mkimage: imx8_optee imx8_u-boot imx8_atf $(IMX8_MKIMAGE_DEPS_DDR) $(IMX8_MKIMAGE_DEPS_HDMI)
+	cd $(IMX8_REPO_ROOT)/imx-mkimage/iMX8M
+	cp $(IMX8_MKIMAGE_DEPS_DDR) .
+	cp $(IMX8_MKIMAGE_DEPS_HDMI) .
+	cp $(IMX8_MKIMAGE_DEPS_OPTEE) .
+	cp $(IMX8_MKIMAGE_DEPS_ATF) .
+	cp $(IMX8_MKIMAGE_DEPS_U-BOOT) .
+	mv mkimage mkimage_uboot	
+	cd ..
+ifeq ($(IMX8_TARGET),NXPEVK_iMX8M_Mini_2GB)
+	$(MAKE) SOC=$(U_BOOT_SOC) flash_spl_uboot
+else
+	$(MAKE) SOC=$(U_BOOT_SOC) flash_hdmi_spl_uboot
+endif
+
+imx8_uefi: imx8_u-boot imx8_tas its/uefi_imx8_unsigned.its
+	export GCC5_AARCH64_PREFIX=$(CROSS_COMPILE)
+	
+	cd $(IMX8_REPO_ROOT)/mu_platform_nxp
+	pip3 install -r requirements.txt --upgrade
+	python3 NXP/$(EDK2_PLATFORM)/PlatformBuild.py --setup
+
+	cd MU_BASECORE
+	$(MAKE) -C BaseTools 
+	cd ..
+	
+	python3 NXP/$(EDK2_PLATFORM)/PlatformBuild.py -V TARGET=RELEASE \
+     PROFILE=DEV MAX_CONCURRENT_THREAD_NUMBER=20
+	
+	cd Build/$(EDK2_PLATFORM)/RELEASE_GCC5/FV
+	cp $(IMX8_REPO_ROOT)/imx-iotcore/build/firmware/its/uefi_imx8_unsigned.its .
+	$(IMX8_REPO_ROOT)/u-boot/tools/mkimage -f uefi_imx8_unsigned.its -r uefi.fit
+
+imx8_build: imx8_uefi imx8_mkimage
+
+VERSION_REPOS= \
+    imx-iotcore \
+    mu_platform_nxp \
+    u-boot \
+    optee_os \
+    imx-atf \
+    imx-mkimage \
+	MSRSec
+
+$(VERSIONS):
+	@echo Logging version information of firmware repositories
+	rm -f $@
+	$(foreach REPO,$(VERSION_REPOS), \
+	echo $(REPO) commit information: >> $@ && \
+	pushd $(IMX8_REPO_ROOT)/$(REPO) && \
+	  git config --get remote.origin.url >> $(CURDIR)/$@ && \
+	  git rev-parse HEAD >> $(CURDIR)/$@ && \
+	  echo $(REPO) diff information: >> $(CURDIR)/$@ && \
+	  git diff HEAD >> $(CURDIR)/$@ && \
+	  echo $(REPO) diff end >> $(CURDIR)/$@ && \
+	popd; )
+
+imx8_update-ffu: imx8_build $(VERSIONS)
+	cp $(VERSIONS) $(IMX8_REPO_ROOT)/imx-iotcore/build/board/$(IMX8_TARGET)/Package/BootLoader/
+	cp $(IMX8_REPO_ROOT)/imx-mkimage/iMX8M/flash.bin $(IMX8_REPO_ROOT)/imx-iotcore/build/board/$(IMX8_TARGET)/Package/BootLoader/flash.bin
+	cp $(IMX8_REPO_ROOT)/mu_platform_nxp/Build/$(EDK2_PLATFORM)/RELEASE_GCC5/FV/uefi.fit $(IMX8_REPO_ROOT)/imx-iotcore/build/board/$(IMX8_TARGET)/Package/BootFirmware/uefi.fit
+
+imx8_commit-firmware: imx8_update-ffu
+	git add $(IMX8_REPO_ROOT)/imx-iotcore/build/board/$(IMX8_TARGET)/Package/BootLoader
+	git add $(IMX8_REPO_ROOT)/imx-iotcore/build/board/$(IMX8_TARGET)/Package/BootFirmware
+	@echo "Successfully copied files to package and staged for commit"


### PR DESCRIPTION
* Add a new makefile for the iMX8 boards.
    - `make -f imx8.mk IMX8_TARGET=NXPEVK_iMX8M_4GB imx8_build` will build new firmware binaries.
    - `make -f imx8.mk IMX8_TARGET=NXPEVK_iMX8M_4GB imx8_update-ffu` will build new firmware binaries AND palce them into the package folders.
* Updated the root Makefile to support iMX8:
    - Calling `make imx8_all` will build everything (**But the outputs will overwrite each other**)
    - `make imx8_update-ffu` will place new copies for each board
    - `make imx8_commit-firmware` will stage for commit
    - Added a `serialize_builds(command, common arguments, serialized list)` function to allow serialized builds with `-j>1` for components which conflict with each other (EDK2, imx8)

TODO:
* We probably don't want to share output folders for each imx8 board
* Case sensitivity still needs to be configured manually for imx8 SPL/U-Boot
* Update the CI pipeline to use this makefile (in progress)


