### PR TITLE
Enable Containers feature for Hummingboard Quad

### DIFF
--- a/build/board/HummingBoardEdge_iMX6Q_2GB/HummingBoardEdge_iMX6Q_2GB_EdgeOEMInput.xml
+++ b/build/board/HummingBoardEdge_iMX6Q_2GB/HummingBoardEdge_iMX6Q_2GB_EdgeOEMInput.xml
@@ -53,7 +53,6 @@
   <Feature>IOT_UMDFDBG_SETTINGS</Feature>
   <Feature>IOT_NANORDPSERVER</Feature>
   <Feature>IOT_CONTAINERS</Feature>
-  <Feature>IOT_ENABLE_FLIGHTSIGNING</Feature>
 </Microsoft>
 <OEM>
   <Feature>IMX_DRIVERS</Feature>

--- a/build/board/HummingBoardEdge_iMX6Q_2GB/HummingBoardEdge_iMX6Q_2GB_EdgeOEMInput.xml
+++ b/build/board/HummingBoardEdge_iMX6Q_2GB/HummingBoardEdge_iMX6Q_2GB_EdgeOEMInput.xml
@@ -53,6 +53,7 @@
   <Feature>IOT_UMDFDBG_SETTINGS</Feature>
   <Feature>IOT_NANORDPSERVER</Feature>
   <Feature>IOT_CONTAINERS</Feature>
+  <Feature>IOT_ENABLE_FLIGHTSIGNING</Feature>
 </Microsoft>
 <OEM>
   <Feature>IMX_DRIVERS</Feature>

--- a/build/board/HummingBoardEdge_iMX6Q_2GB/HummingBoardEdge_iMX6Q_2GB_ProductionOEMInput.xml
+++ b/build/board/HummingBoardEdge_iMX6Q_2GB/HummingBoardEdge_iMX6Q_2GB_ProductionOEMInput.xml
@@ -51,6 +51,7 @@
   <Feature>IOT_ENABLE_TESTSIGNING</Feature>
   <Feature>IOT_UMDFDBG_SETTINGS</Feature>
   <Feature>IOT_NANORDPSERVER</Feature>
+  <Feature>IOT_CONTAINERS</Feature>
 </Microsoft>
 <OEM>
   <Feature>IMX_DRIVERS</Feature>

--- a/build/board/HummingBoardEdge_iMX6Q_2GB/HummingBoardEdge_iMX6Q_2GB_ProductionOEMInput.xml
+++ b/build/board/HummingBoardEdge_iMX6Q_2GB/HummingBoardEdge_iMX6Q_2GB_ProductionOEMInput.xml
@@ -52,6 +52,7 @@
   <Feature>IOT_UMDFDBG_SETTINGS</Feature>
   <Feature>IOT_NANORDPSERVER</Feature>
   <Feature>IOT_CONTAINERS</Feature>
+  <Feature>IOT_ENABLE_FLIGHTSIGNING</Feature>
 </Microsoft>
 <OEM>
   <Feature>IMX_DRIVERS</Feature>

--- a/build/board/HummingBoardEdge_iMX6Q_2GB/HummingBoardEdge_iMX6Q_2GB_ProductionOEMInput.xml
+++ b/build/board/HummingBoardEdge_iMX6Q_2GB/HummingBoardEdge_iMX6Q_2GB_ProductionOEMInput.xml
@@ -52,7 +52,6 @@
   <Feature>IOT_UMDFDBG_SETTINGS</Feature>
   <Feature>IOT_NANORDPSERVER</Feature>
   <Feature>IOT_CONTAINERS</Feature>
-  <Feature>IOT_ENABLE_FLIGHTSIGNING</Feature>
 </Microsoft>
 <OEM>
   <Feature>IMX_DRIVERS</Feature>

--- a/build/board/HummingBoardEdge_iMX6Q_2GB/HummingBoardEdge_iMX6Q_2GB_TestOEMInput.xml
+++ b/build/board/HummingBoardEdge_iMX6Q_2GB/HummingBoardEdge_iMX6Q_2GB_TestOEMInput.xml
@@ -52,6 +52,7 @@
   <Feature>IOT_ENABLE_TESTSIGNING</Feature>
   <Feature>IOT_UMDFDBG_SETTINGS</Feature>
   <Feature>IOT_NANORDPSERVER</Feature>
+  <Feature>IOT_CONTAINERS</Feature>
 </Microsoft>
 <OEM>
   <Feature>IMX_DRIVERS</Feature>

--- a/build/board/HummingBoardEdge_iMX6Q_2GB/HummingBoardEdge_iMX6Q_2GB_TestOEMInput.xml
+++ b/build/board/HummingBoardEdge_iMX6Q_2GB/HummingBoardEdge_iMX6Q_2GB_TestOEMInput.xml
@@ -53,7 +53,6 @@
   <Feature>IOT_UMDFDBG_SETTINGS</Feature>
   <Feature>IOT_NANORDPSERVER</Feature>
   <Feature>IOT_CONTAINERS</Feature>
-  <Feature>IOT_ENABLE_FLIGHTSIGNING</Feature>
 </Microsoft>
 <OEM>
   <Feature>IMX_DRIVERS</Feature>

--- a/build/board/HummingBoardEdge_iMX6Q_2GB/HummingBoardEdge_iMX6Q_2GB_TestOEMInput.xml
+++ b/build/board/HummingBoardEdge_iMX6Q_2GB/HummingBoardEdge_iMX6Q_2GB_TestOEMInput.xml
@@ -53,6 +53,7 @@
   <Feature>IOT_UMDFDBG_SETTINGS</Feature>
   <Feature>IOT_NANORDPSERVER</Feature>
   <Feature>IOT_CONTAINERS</Feature>
+  <Feature>IOT_ENABLE_FLIGHTSIGNING</Feature>
 </Microsoft>
 <OEM>
   <Feature>IMX_DRIVERS</Feature>


### PR DESCRIPTION
To natively support Azure IoT Edge out of the box, we need to include the
IOT_CONTAINERS feature.