### PR TITLE
IMX8: Fix BSP generation for iMX8M

### DIFF
--- a/build/tools/BuildBSP.bat
+++ b/build/tools/BuildBSP.bat
@@ -273,7 +273,7 @@ copy %INFO_ROOT%\BootFirmware\uefi.fit %PKG_ROOT%\BootFirmware\BootFirmware\ >NU
 
 mkdir %PKG_ROOT%\BootLoader\BootLoader >NUL 2>NUL
 copy %INFO_ROOT%\BootLoader\BootLoader.wm.xml %PKG_ROOT%\BootLoader\ >NUL
-copy %INFO_ROOT%\BootLoader\firmware_fit.merged %PKG_ROOT%\BootLoader\BootLoader\ >NUL
+copy %INFO_ROOT%\BootLoader\flash.bin %PKG_ROOT%\BootLoader\BootLoader\ >NUL
 
 :: Copy the UpdateOS Package XML
 mkdir %PKG_ROOT%\SVPlatExtensions >NUL 2>NUL

--- a/components/Arm64CRTRuntime/Arm64CRTRuntime.vcxproj
+++ b/components/Arm64CRTRuntime/Arm64CRTRuntime.vcxproj
@@ -70,7 +70,7 @@
   <ItemGroup>
     <Pkggen Include="Arm64CRTRuntime.wm.xml">
       <AdditionalOptions>/universalbsp</AdditionalOptions>
-      <Variables>"HIVE_ROOT=$(CoreSystem_HivesPath);WIM_ROOT=$(CoreSystem_HivesPath);_REDIST=$(RuntimeRedistDirectory);_RELEASEDIR=$(PackageDir);TARGETNAME=$(TargetName);TARGETEXT=$(TargetExt);$(PkgGen_DefaultDriverDest);OEMNAME=$(OEMName)"</Variables>
+      <Variables>"HIVE_ROOT=$(CoreSystem_HivesPath);WIM_ROOT=$(CoreSystem_HivesPath);_RELEASEDIR=$(PackageDir);TARGETNAME=$(TargetName);TARGETEXT=$(TargetExt);$(PkgGen_DefaultDriverDest);OEMNAME=$(OEMName)"</Variables>
     </Pkggen>
   </ItemGroup>
   <ItemGroup>
@@ -78,6 +78,17 @@
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Driver.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <CopyFileToFolders Include="$(RuntimeRedistDirectory)msvcp140.dll">
+      <FileType>Document</FileType>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="$(RuntimeRedistDirectory)vcruntime140.dll">
+      <FileType>Document</FileType>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="$(RuntimeRedistDirectory)vccorlib140.dll">
+      <FileType>Document</FileType>
+    </CopyFileToFolders>
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/components/Arm64CRTRuntime/Arm64CRTRuntime.wm.xml
+++ b/components/Arm64CRTRuntime/Arm64CRTRuntime.wm.xml
@@ -11,8 +11,8 @@
   <!-- workaround to drop VC runtime 140 to system32 directory since it isn't part of
        Arm64 IoT image -->
   <files>
-    <file source="$(_Redist)vcruntime140.dll" destinationDir="$(runtime.system32)" />
-    <file source="$(_Redist)vccorlib140.dll" destinationDir="$(runtime.system32)" />
-    <file source="$(_Redist)msvcp140.dll" destinationDir="$(runtime.system32)" />
+    <file source="$(_RELEASEDIR)vcruntime140.dll" destinationDir="$(runtime.system32)" />
+    <file source="$(_RELEASEDIR)vccorlib140.dll" destinationDir="$(runtime.system32)" />
+    <file source="$(_RELEASEDIR)msvcp140.dll" destinationDir="$(runtime.system32)" />
   </files>
 </identity>


### PR DESCRIPTION
- Copy ARM64 CRT files to package output directory
- Update ARM64 CRT package definition to read from output directory
- Copy flash.bin file to BSP directory for ARM64 BootLoader package